### PR TITLE
Change sftp test fixture from package scope to function scope

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 from tests.test_server import *
 
 
-@pytest.fixture(scope="package")
+@pytest.fixture(scope="function")
 def sftp():
     """This fixture provides a pysftp.Connection object that's shared
     across the entire tests package. If there's a problem connecting,

--- a/tests/unit/test_sftp_fixture.py
+++ b/tests/unit/test_sftp_fixture.py
@@ -1,0 +1,8 @@
+def test_close_sftp(sftp):
+    """Closes the SFTP connection so that future tests can verify that they get a fresh sftp object."""
+    sftp.close()
+
+def test_sftp_fixture_is_function_scoped(sftp):
+    """Tests that the sftp object is fresh for this function."""
+
+    sftp.listdir('.')


### PR DESCRIPTION
Change sftp test fixture form package scope to function scope, which stops tests from interfering with each other. One test can safely close or even corrupt an sftp object without affecting other tests.